### PR TITLE
Settings validation: add dummy callback that always returns true

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ func settingsDenyPorts(payload []byte) map[uint16]struct{} {
 
 func main() {
 	wapc.RegisterFunctions(wapc.Functions{
-		"validate": validate,
+		"validate":          validate,
+		"validate_settings": validateSettings,
 	})
 }

--- a/settings.go
+++ b/settings.go
@@ -1,0 +1,5 @@
+package main
+
+func validateSettings(payload []byte) ([]byte, error) {
+	return []byte(`{"valid":true}`), nil
+}


### PR DESCRIPTION
Implements https://github.com/kubewarden/ingress-policy/issues/3

This strictly implements the card to not get into early abstractions, but I think we should look into generalizing this into the SDK.