### PR TITLE
fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,5 +26,3 @@ jobs:
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go.yml@v1
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/policies/ingress
-    secrets:
-      workflow-pat: ${{ secrets.WORKFLOW_PAT }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SOURCE_FILES := $(shell find . -type f -name '*.go')
 
 policy.wasm: $(SOURCE_FILES) go.mod go.sum
-	docker run --rm -v ${PWD}:/src -w /src tinygo/tinygo:0.18.0 tinygo build \
+	docker run --rm -v ${PWD}:/src -w /src tinygo/tinygo:0.26.0 tinygo build \
 		-o policy.wasm -target=wasi -no-debug .
 
 annotated-policy.wasm: policy.wasm metadata.yml


### PR DESCRIPTION
- chore(deps): update to latest version of tinygo
- fix: GitHub release

Attempts to fix https://github.com/kubewarden/ingress-policy/issues/23